### PR TITLE
release v0.8.4.strateos

### DIFF
--- a/lib/jsonapi/resource_controller_metal.rb
+++ b/lib/jsonapi/resource_controller_metal.rb
@@ -5,7 +5,6 @@ module JSONAPI
       ActionController::Rendering,
       ActionController::Renderers::All,
       ActionController::StrongParameters,
-      ActionController::ForceSSL,
       ActionController::Instrumentation,
       JSONAPI::ActsAsResourceController
     ].freeze

--- a/lib/jsonapi/resources/version.rb
+++ b/lib/jsonapi/resources/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Resources
-    VERSION = '0.9.0.pre'
+    VERSION = '0.8.4.strateos'
   end
 end


### PR DESCRIPTION
Remove `ActionController::ForceSSL` from `lib/jsonapi/resource_controller_metal.rb`. Rails 6.1 has removed the usage of `ActionController::ForceSSL`